### PR TITLE
Better new translation initialization

### DIFF
--- a/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
+++ b/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
@@ -208,13 +208,13 @@ public class GodToolsTranslationService
 		logger.info("Starting translation data copy at");
 		if (currentTranslation != null)
 		{
-			newTranslationProcess.copyPageAndTranslationData(currentTranslation, newTranslation);
+			newTranslationProcess.copyPageAndTranslationData(currentTranslation, newTranslation, false);
 			newTranslationProcess.copyPackageTranslationData(currentTranslation, newTranslation);
 		}
 		else
 		{
 			Translation baseTranslation = loadBaseTranslation(gtPackage);
-			newTranslationProcess.copyPageAndTranslationData(baseTranslation, newTranslation);
+			newTranslationProcess.copyPageAndTranslationData(baseTranslation, newTranslation, true);
 			newTranslationProcess.copyPackageTranslationData(baseTranslation, newTranslation);
 		}
 		logger.info("Finished translation data copy");

--- a/src/main/java/org/cru/godtools/api/translations/NewTranslationCreation.java
+++ b/src/main/java/org/cru/godtools/api/translations/NewTranslationCreation.java
@@ -51,13 +51,23 @@ public class NewTranslationCreation
 	 * Just after a new PageStructure is saved, a copied set of current PageStructure's TranslationElements are saved associated
 	 * to the new PageStructure.
 	 */
-	public void copyPageAndTranslationData(Translation currentTranslation, Translation newTranslation)
+	public void copyPageAndTranslationData(Translation currentTranslation, Translation newTranslation, boolean translationIsNew)
 	{
 		for(PageStructure currentPageStructure : pageStructureService.selectByTranslationId(currentTranslation.getId()))
 		{
 			PageStructure copy = PageStructure.copyOf(currentPageStructure);
 			copy.setId(UUID.randomUUID());
 			copy.setTranslationId(newTranslation.getId());
+
+			// when starting a new translation, set these fields to null so they get pushed to OneSky
+			if(translationIsNew)
+			{
+				copy.setPercentCompleted(null);
+				copy.setWordCount(null);
+				copy.setStringCount(null);
+				copy.setLastUpdated(null);
+			}
+
 			pageStructureService.insert(copy);
 
 			// it's easier to do this in the context of the new page, so that we don't have to remember


### PR DESCRIPTION
- when creating a translation in a new language, any translation status data from the base translation (English) should be cleared out
- if it's not, then once the new translation is created in the database, it will appear as if the translation has already been uploaded to the translation tool, when in fact it has not.
