### PR TITLE
Webapp endpoints

### DIFF
--- a/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationRetrieval.java
+++ b/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationRetrieval.java
@@ -5,7 +5,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.cru.godtools.api.packages.utils.FileZipper;
-import org.cru.godtools.api.translations.model.Content;
+import org.cru.godtools.api.translations.model.ContentsFile;
 import org.cru.godtools.api.translations.drafts.DraftUpdateJobScheduler;
 import org.cru.godtools.domain.GodToolsVersion;
 import org.cru.godtools.domain.GuavaHashGenerator;
@@ -209,7 +209,7 @@ public class GodToolsTranslationRetrieval
         }
 
         return Response
-				.ok(Content.createContentsFile(godToolsTranslations, languageCode.toString()))
+				.ok(ContentsFile.createContentsFile(godToolsTranslations, languageCode.toString()))
                 .build();
     }
 

--- a/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
+++ b/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
@@ -90,8 +90,7 @@ public class GodToolsTranslationService
 					languageCode);
 		}
 
-		List<TranslationElement> translationElementList = translationElementService.selectByTranslationIdPageStructureId(translation.getId(),
-				pageId);
+		List<TranslationElement> translationElementList = getTranslationElements(pageId, translation);
 
 		pageStructure.setTranslatedFields(TranslationElement.createMapOfTranslationElements(translationElementList));
 		pageStructure.replaceImageNamesWithImageHashes(Image.createMapOfImages(getImagesUsedInThisTranslation(packageStructure)));
@@ -106,6 +105,12 @@ public class GodToolsTranslationService
 		}
 
 		return pageStructure;
+	}
+
+	private List<TranslationElement> getTranslationElements(UUID pageStructureId, Translation translation)
+	{
+		return translationElementService.selectByTranslationIdPageStructureId(translation.getId(),
+				pageStructureId);
 	}
 
 	public void updatePageLayout(UUID pageId, Document updatedPageLayout)

--- a/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
+++ b/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
@@ -82,10 +82,13 @@ public class GodToolsTranslationService
 		Package gtPackage = packageService.selectById(translation.getPackageId());
 		PackageStructure packageStructure = packageStructureService.selectByPackageId(gtPackage.getId());
 
-		draftTranslationProcess.updateFromTranslationTool(gtPackage.getTranslationProjectId(),
-				translation,
-				Lists.newArrayList(pageStructure),
-				languageCode);
+		if(translation.isDraft())
+		{
+			draftTranslationProcess.updateFromTranslationTool(gtPackage.getTranslationProjectId(),
+					translation,
+					Lists.newArrayList(pageStructure),
+					languageCode);
+		}
 
 		List<TranslationElement> translationElementList = translationElementService.selectByTranslationIdPageStructureId(translation.getId(),
 				pageId);
@@ -93,7 +96,14 @@ public class GodToolsTranslationService
 		pageStructure.setTranslatedFields(TranslationElement.createMapOfTranslationElements(translationElementList));
 		pageStructure.replaceImageNamesWithImageHashes(Image.createMapOfImages(getImagesUsedInThisTranslation(packageStructure)));
 
-		updateCache(translation, pageStructure);
+		/* When this method was initially created it was only used to interact with 'draft' translations.  Now this current update will use
+		 * this method to retrieve a page of a live translation as well.  Until more analysis can be done, assume the cache should only be
+		 * updated when fetching a draft page.  RTC 2/26/15
+		 */
+		if(translation.isDraft())
+		{
+			updateCache(translation, pageStructure);
+		}
 
 		return pageStructure;
 	}

--- a/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
+++ b/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
@@ -4,9 +4,10 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import org.cru.godtools.api.translations.model.ConfigFile;
+
 import org.cru.godtools.api.translations.drafts.DraftUpdateJobScheduler;
 import org.cru.godtools.api.cache.GodToolsCache;
+import org.cru.godtools.api.translations.model.ConfigFile;
 import org.cru.godtools.domain.GodToolsVersion;
 import org.cru.godtools.domain.images.Image;
 import org.cru.godtools.domain.images.ImageService;
@@ -82,35 +83,20 @@ public class GodToolsTranslationService
 		Package gtPackage = packageService.selectById(translation.getPackageId());
 		PackageStructure packageStructure = packageStructureService.selectByPackageId(gtPackage.getId());
 
-		if(translation.isDraft())
-		{
-			draftTranslationProcess.updateFromTranslationTool(gtPackage.getTranslationProjectId(),
-					translation,
-					Lists.newArrayList(pageStructure),
-					languageCode);
-		}
+		draftTranslationProcess.updateFromTranslationTool(gtPackage.getTranslationProjectId(),
+				translation,
+				Lists.newArrayList(pageStructure),
+				languageCode);
 
-		List<TranslationElement> translationElementList = getTranslationElements(pageId, translation);
+		List<TranslationElement> translationElementList = translationElementService.selectByTranslationIdPageStructureId(translation.getId(),
+				pageId);
 
 		pageStructure.setTranslatedFields(TranslationElement.createMapOfTranslationElements(translationElementList));
 		pageStructure.replaceImageNamesWithImageHashes(Image.createMapOfImages(getImagesUsedInThisTranslation(packageStructure)));
 
-		/* When this method was initially created it was only used to interact with 'draft' translations.  Now this current update will use
-		 * this method to retrieve a page of a live translation as well.  Until more analysis can be done, assume the cache should only be
-		 * updated when fetching a draft page.  RTC 2/26/15
-		 */
-		if(translation.isDraft())
-		{
-			updateCache(translation, pageStructure);
-		}
+		updateCache(translation, pageStructure);
 
 		return pageStructure;
-	}
-
-	private List<TranslationElement> getTranslationElements(UUID pageStructureId, Translation translation)
-	{
-		return translationElementService.selectByTranslationIdPageStructureId(translation.getId(),
-				pageStructureId);
 	}
 
 	public void updatePageLayout(UUID pageId, Document updatedPageLayout)

--- a/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
+++ b/src/main/java/org/cru/godtools/api/translations/GodToolsTranslationService.java
@@ -4,7 +4,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import org.cru.godtools.api.translations.model.Config;
+import org.cru.godtools.api.translations.model.ConfigFile;
 import org.cru.godtools.api.translations.drafts.DraftUpdateJobScheduler;
 import org.cru.godtools.api.cache.GodToolsCache;
 import org.cru.godtools.domain.GodToolsVersion;
@@ -168,13 +168,13 @@ public class GodToolsTranslationService
 		}
 	}
 
-	public Config getConfig(String packageCode, LanguageCode languageCode)
+	public ConfigFile getConfig(String packageCode, LanguageCode languageCode)
 	{
 		Package gtPackage = packageService.selectByCode(packageCode);
 		Translation translation = getTranslationFromDatabase(languageCode, packageCode, GodToolsVersion.DRAFT_VERSION);
 		PackageStructure packageStructure = packageStructureService.selectByPackageId(gtPackage.getId());
 		packageStructure.replacePageNamesWithPageHashes(PageStructure.createMapOfPageStructures(pageStructureService.selectByTranslationId(translation.getId())));
-		return Config.createConfigFile(packageStructure);
+		return ConfigFile.createConfigFile(packageStructure);
 	}
 
 	public GodToolsTranslation getTranslation(Translation translation)

--- a/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
+++ b/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
@@ -185,47 +185,6 @@ public class TranslationResource
 
 	@GET
 	@Path("/{language}/{package}/pages/{pageId}")
-	@Produces("application/xml")
-	public Response getXmlPage(@PathParam("language") String languageCode,
-							@PathParam("package") String packageCode,
-							@PathParam("pageId") UUID pageId,
-							@QueryParam("interpreter") Integer minimumInterpreterVersionParam,
-							@HeaderParam("interpreter") Integer minimumInterpreterVersionHeader,
-							@HeaderParam("Authorization") String authTokenHeader,
-							@QueryParam("Authorization") String authTokenParam) throws IOException, ParserConfigurationException
-	{
-		log.info("Requesting draft page update for package: " + packageCode + " and language: " + languageCode + " and page ID: " + pageId);
-
-		AuthorizationRecord.checkAuthorization(authService.getAuthorizationRecord(authTokenParam, authTokenHeader), clock.currentDateTime());
-
-		Optional<Response> optionalBadRequestResponse = verifyRequestedPageBelongsToPageAndLanguage(packageCode, languageCode, pageId);
-
-		if(optionalBadRequestResponse.isPresent())
-		{
-			return optionalBadRequestResponse.get();
-		}
-
-		PageStructure pageStructure = pageStructureService.selectByid(pageId);
-
-		if(pageStructure == null)
-		{
-			return Response
-					.status(Response.Status.NOT_FOUND)
-					.build();
-		}
-
-		List<TranslationElement> translationElements = translationElementService.selectByTranslationIdPageStructureId(translationService.selectById(pageStructure.getTranslationId()).getId(),
-				pageId);
-
-		PageFile pageFile = PageFile.fromTranslationElements(translationElements);
-
-		return Response
-				.ok(pageFile)
-				.build();
-	}
-
-	@GET
-	@Path("/{language}/{package}/pages/{pageId}")
 	@Produces("application/json")
 	public Response getJsonPage(@PathParam("language") String languageCode,
 							   @PathParam("package") String packageCode,

--- a/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
+++ b/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
@@ -6,6 +6,7 @@ import org.cru.godtools.domain.authentication.AuthorizationRecord;
 import org.cru.godtools.domain.authentication.AuthorizationService;
 import org.cru.godtools.domain.GodToolsVersion;
 import org.cru.godtools.domain.languages.LanguageCode;
+import org.cru.godtools.domain.packages.PageStructure;
 import org.cru.godtools.domain.translations.Translation;
 import org.jboss.logging.Logger;
 
@@ -196,8 +197,10 @@ public class TranslationResource
 
 		AuthorizationRecord.checkAuthorization(authService.getAuthorizationRecord(authTokenParam, authTokenHeader), clock.currentDateTime());
 
+		PageStructure pageStructure = godToolsTranslationService.getPage(new LanguageCode(languageCode), pageId);
+
 		return translationRetrieval
 				.setCompressed(false)
-				.buildSinglePageResponse(godToolsTranslationService.getPage(new LanguageCode(languageCode),pageId));
+				.buildSinglePageResponse(pageStructure);
 	}
 }

--- a/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
+++ b/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
@@ -207,6 +207,13 @@ public class TranslationResource
 
 		PageStructure pageStructure = pageStructureService.selectByid(pageId);
 
+		if(pageStructure == null)
+		{
+			return Response
+					.status(Response.Status.NOT_FOUND)
+					.build();
+		}
+
 		List<TranslationElement> translationElements = translationElementService.selectByTranslationIdPageStructureId(translationService.selectById(pageStructure.getTranslationId()).getId(),
 				pageId);
 
@@ -240,6 +247,13 @@ public class TranslationResource
 		}
 
 		PageStructure pageStructure = pageStructureService.selectByid(pageId);
+
+		if(pageStructure == null)
+		{
+			return Response
+					.status(Response.Status.NOT_FOUND)
+					.build();
+		}
 
 		List<TranslationElement> translationElements = translationElementService.selectByTranslationIdPageStructureId(translationService.selectById(pageStructure.getTranslationId()).getId(),
 				pageId);

--- a/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
+++ b/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
@@ -19,10 +19,12 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.UUID;
 
 /**
  * Contains RESTful endpoints for delivering GodTools "translation" resources.
@@ -137,5 +139,65 @@ public class TranslationResource
 			log.info("Done publishing!");
 		}
 		return Response.noContent().build();
+	}
+
+	@GET
+	@Path("/{language}/{package}/config")
+	@Produces("application/json")
+	public Response getJsonConfig(@PathParam("language") String languageCode,
+							  @PathParam("package") String packageCode,
+							  @QueryParam("interpreter") Integer minimumInterpreterVersionParam,
+							  @HeaderParam("interpreter") Integer minimumInterpreterVersionHeader,
+							  @QueryParam("compressed") String compressed,
+							  @HeaderParam("Authorization") String authTokenHeader,
+							  @QueryParam("Authorization") String authTokenParam) throws IOException
+	{
+		log.info("Requesting config.xml for package: " + packageCode + " and language: " + languageCode);
+
+		AuthorizationRecord.checkAuthorization(authService.getAuthorizationRecord(authTokenParam, authTokenHeader), clock.currentDateTime());
+
+		return Response
+				.ok(godToolsTranslationService.getConfig(packageCode, new LanguageCode(languageCode)))
+				.build();
+	}
+
+	@GET
+	@Path("/{language}/{package}/pages/{pageId}")
+	@Produces("application/xml")
+	public Response getXmlPage(@PathParam("language") String languageCode,
+							@PathParam("package") String packageCode,
+							@PathParam("pageId") UUID pageId,
+							@QueryParam("interpreter") Integer minimumInterpreterVersionParam,
+							@HeaderParam("interpreter") Integer minimumInterpreterVersionHeader,
+							@HeaderParam("Authorization") String authTokenHeader,
+							@QueryParam("Authorization") String authTokenParam) throws IOException, ParserConfigurationException
+	{
+		log.info("Requesting draft page update for package: " + packageCode + " and language: " + languageCode + " and page ID: " + pageId);
+
+		AuthorizationRecord.checkAuthorization(authService.getAuthorizationRecord(authTokenParam, authTokenHeader), clock.currentDateTime());
+
+		return translationRetrieval
+				.setCompressed(false)
+				.buildSinglePageResponse(godToolsTranslationService.getPage(new LanguageCode(languageCode),pageId));
+	}
+
+	@GET
+	@Path("/{language}/{package}/pages/{pageId}")
+	@Produces("application/json")
+	public Response getJsonPage(@PathParam("language") String languageCode,
+							   @PathParam("package") String packageCode,
+							   @PathParam("pageId") UUID pageId,
+							   @QueryParam("interpreter") Integer minimumInterpreterVersionParam,
+							   @HeaderParam("interpreter") Integer minimumInterpreterVersionHeader,
+							   @HeaderParam("Authorization") String authTokenHeader,
+							   @QueryParam("Authorization") String authTokenParam) throws IOException, ParserConfigurationException
+	{
+		log.info("Requesting draft page update for package: " + packageCode + " and language: " + languageCode + " and page ID: " + pageId);
+
+		AuthorizationRecord.checkAuthorization(authService.getAuthorizationRecord(authTokenParam, authTokenHeader), clock.currentDateTime());
+
+		return translationRetrieval
+				.setCompressed(false)
+				.buildSinglePageResponse(godToolsTranslationService.getPage(new LanguageCode(languageCode),pageId));
 	}
 }

--- a/src/main/java/org/cru/godtools/api/translations/model/AboutElement.java
+++ b/src/main/java/org/cru/godtools/api/translations/model/AboutElement.java
@@ -16,7 +16,7 @@ import javax.xml.bind.annotation.XmlAttribute;
  *  <about filename="57b47e36-0697-4618-b8dc-878f45c49586.xml">A propos</about>
  * </document>
  */
-public class About
+public class AboutElement
 {
 	String filename;
 	String title;

--- a/src/main/java/org/cru/godtools/api/translations/model/ConfigFile.java
+++ b/src/main/java/org/cru/godtools/api/translations/model/ConfigFile.java
@@ -31,68 +31,72 @@ import java.util.List;
  * </document>
  */
 @XmlRootElement
-public class Config
+public class ConfigFile
 {
-	List<Page> pages = Lists.newArrayList();
-	org.cru.godtools.api.translations.model.About about = new org.cru.godtools.api.translations.model.About();
-	PackageName packageName = new PackageName();
+	@XmlElement(name = "page")
+	List<PageElement> pageElements = Lists.newArrayList();
 
-	public static Config createConfigFile(PackageStructure packageStructure)
+	@XmlElement(name = "about")
+	AboutElement about = new AboutElement();
+
+	@XmlElement(name = "packagename")
+	PackagenameElement packageName = new PackagenameElement();
+
+	public static ConfigFile createConfigFile(PackageStructure packageStructure)
 	{
-		Config config = new Config();
+		ConfigFile configFile = new ConfigFile();
 
 		Document xmlPackageStructure = packageStructure.getXmlContent();
 
 		for(Element element : XmlDocumentSearchUtilities.findElements(xmlPackageStructure, "packagename"))
 		{
-			config.packageName.setTitle(element.getTextContent());
+			configFile.packageName.setTitle(element.getTextContent());
 		}
 		for(Element element : XmlDocumentSearchUtilities.findElements(xmlPackageStructure, "page"))
 		{
-			Page page = new Page();
-			page.setFilename(element.getAttribute("filename"));
-			page.setTitle(element.getTextContent());
-			config.pages.add(page);
+			PageElement pageElement = new PageElement();
+			pageElement.setFilename(element.getAttribute("filename"));
+			pageElement.setTitle(element.getTextContent());
+			configFile.pageElements.add(pageElement);
 		}
 		for(Element element : XmlDocumentSearchUtilities.findElements(xmlPackageStructure, "about"))
 		{
-			config.about.setFilename(element.getAttribute("about"));
-			config.about.setTitle(element.getTextContent());
+			configFile.about.setFilename(element.getAttribute("about"));
+			configFile.about.setTitle(element.getTextContent());
 		}
 
-		return config;
+		return configFile;
 	}
 
-	@XmlElementWrapper(name = "pages")
 	@XmlElement(name = "page")
-	public List<Page> getPageSet()
+	public List<PageElement> getPageSet()
 	{
-		return pages;
+		return pageElements;
 	}
 
-	public void setPageSet(List<Page> pages)
+	public void setPageSet(List<PageElement> pageElements)
 	{
-		this.pages = pages;
+		this.pageElements = pageElements;
 	}
 
 	@XmlElement
-	public PackageName getPackageName()
+	public PackagenameElement getPackageName()
 	{
 		return packageName;
 	}
 
-	public void setPackageName(PackageName packageName)
+	public void setPackageName(PackagenameElement packageName)
 	{
 		this.packageName = packageName;
 	}
 
 	@XmlElement
-	public org.cru.godtools.api.translations.model.About getAbout()
+	public AboutElement getAbout()
 	{
 		return about;
 	}
 
-	public void setAbout(org.cru.godtools.api.translations.model.About about)
+	public void setAbout(AboutElement about)
 	{
 		this.about = about;
 	}

--- a/src/main/java/org/cru/godtools/api/translations/model/ContentsFile.java
+++ b/src/main/java/org/cru/godtools/api/translations/model/ContentsFile.java
@@ -6,7 +6,6 @@ import org.cru.godtools.api.translations.GodToolsTranslation;
 import org.cru.godtools.domain.GuavaHashGenerator;
 
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Collection;
 import java.util.Set;
@@ -26,18 +25,18 @@ import java.util.Set;
  *         <resource config="2c510fda-fb80-4c22-9792-195f36232b48.xml" icon="30adeee865dd2ff568b11715e9077ffbb851bb65.png" language="fr" name="Connaître Dieu Personnellement" package="kgp" status="live" version="1.1"/>
  *     </content>
  */
-@XmlRootElement
-public class Content
+@XmlRootElement(name="content")
+public class ContentsFile
 {
-	Set<Resource> resourceSet = Sets.newHashSet();
+	Set<ResourceElement> resourceSet = Sets.newHashSet();
 
-	public static Content createContentsFile(Collection<GodToolsTranslation> godToolsTranslations, String languageCode)
+	public static ContentsFile createContentsFile(Collection<GodToolsTranslation> godToolsTranslations, String languageCode)
 	{
-		Content content = new Content();
+		ContentsFile contentsFile = new ContentsFile();
 
 		for (GodToolsTranslation godToolsTranslation : godToolsTranslations)
 		{
-			Resource resource = new Resource();
+			ResourceElement resource = new ResourceElement();
 			resource.setPackageCode(godToolsTranslation.getPackageCode());
 			resource.setLanguage(languageCode);
 			resource.setConfig(godToolsTranslation.getTranslation().getId() + ".xml");
@@ -53,20 +52,19 @@ public class Content
 				resource.setIcon("missing");
 			}
 
-			content.resourceSet.add(resource);
+			contentsFile.resourceSet.add(resource);
 		}
 
-		return content;
+		return contentsFile;
 	}
 
-	@XmlElementWrapper(name = "resources")
 	@XmlElement(name = "resource")
-	public Set<Resource> getResourceSet()
+	public Set<ResourceElement> getResourceSet()
 	{
 		return resourceSet;
 	}
 
-	public void setResourceSet(Set<Resource> resourceSet)
+	public void setResourceSet(Set<ResourceElement> resourceSet)
 	{
 		this.resourceSet = resourceSet;
 	}

--- a/src/main/java/org/cru/godtools/api/translations/model/PackagenameElement.java
+++ b/src/main/java/org/cru/godtools/api/translations/model/PackagenameElement.java
@@ -6,7 +6,7 @@ import javax.xml.bind.annotation.XmlAttribute;
  * Represents the package name element of a God Tools resource.
  *
  * This class PackageName isn't could be used to render content, but it's not likely that it would b/c its sibling elements
- * @see Page aren't build that way.
+ * @see PageElement aren't build that way.
  *
  * It is currently used by @see Config to build a list of XML elements or JSON objects that
  * represent a Page in a God Tools config file.
@@ -18,7 +18,7 @@ import javax.xml.bind.annotation.XmlAttribute;
  *  <packagename>Connaître Dieu Personnellement</packagename>
  * </document>
  */
-public class PackageName
+public class PackagenameElement
 {
 	String title;
 

--- a/src/main/java/org/cru/godtools/api/translations/model/PageElement.java
+++ b/src/main/java/org/cru/godtools/api/translations/model/PageElement.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlAttribute;
  *  <page filename="cfcf98c0-2626-4b8e-b6b9-088213209a7d.xml" thumb="PageThumb_01.png">Page d'Accueil</page>
  * </document>
  */
-public class Page
+public class PageElement
 {
 	String filename;
 	String title;

--- a/src/main/java/org/cru/godtools/api/translations/model/PageFile.java
+++ b/src/main/java/org/cru/godtools/api/translations/model/PageFile.java
@@ -1,0 +1,40 @@
+package org.cru.godtools.api.translations.model;
+
+import com.google.common.collect.Maps;
+import org.cru.godtools.domain.packages.TranslationElement;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Created by ryancarlson on 2/26/15.
+ */
+@XmlRootElement
+public class PageFile
+{
+	Map<UUID, String> translatedStrings = Maps.newHashMap();
+
+	public static PageFile fromTranslationElements(Collection<TranslationElement> translationElementCollection)
+	{
+		PageFile pageFile = new PageFile();
+
+		for(TranslationElement translationElement : translationElementCollection)
+		{
+			pageFile.translatedStrings.put(translationElement.getId(), translationElement.getTranslatedText());
+		}
+
+		return pageFile;
+	}
+
+	public Map<UUID, String> getTranslatedStrings()
+	{
+		return translatedStrings;
+	}
+
+	public void setTranslatedStrings(Map<UUID, String> translatedStrings)
+	{
+		this.translatedStrings = translatedStrings;
+	}
+}

--- a/src/main/java/org/cru/godtools/api/translations/model/ResourceElement.java
+++ b/src/main/java/org/cru/godtools/api/translations/model/ResourceElement.java
@@ -1,12 +1,13 @@
 package org.cru.godtools.api.translations.model;
 
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 import java.math.BigDecimal;
 
 /**
  * Represents a resource element in a @see Content file that has 'meta' information about a God Tools resource.
  *
- * There are various attibutes here within that have meaning in a God Tools resource
+ * There are various attributes here within that have meaning in a God Tools resource
  * *
  * Its XML representation looks like this example (some pages omitted):
  *
@@ -15,7 +16,7 @@ import java.math.BigDecimal;
  *         <resource config="2c510fda-fb80-4c22-9792-195f36232b48.xml" icon="30adeee865dd2ff568b11715e9077ffbb851bb65.png" language="fr" name="Connaître Dieu Personnellement" package="kgp" status="live" version="1.1"/>
  *     </content>
  */
-public class Resource
+public class ResourceElement
 {
 	/**
 	 * Name of the config file.  This is the file that iOS or Android clients will use to know the structure of the God Tools resource

--- a/src/test/java/org/cru/godtools/api/packages/PackageResourceTest.java
+++ b/src/test/java/org/cru/godtools/api/packages/PackageResourceTest.java
@@ -2,8 +2,8 @@ package org.cru.godtools.api.packages;
 
 import org.ccci.util.xml.XmlDocumentSearchUtilities;
 import org.cru.godtools.api.packages.utils.FileZipper;
-import org.cru.godtools.api.translations.model.Content;
-import org.cru.godtools.api.translations.model.Resource;
+import org.cru.godtools.api.translations.model.ContentsFile;
+import org.cru.godtools.api.translations.model.ResourceElement;
 import org.cru.godtools.domain.TestSqlConnectionProducer;
 import org.cru.godtools.domain.UnittestDatabaseBuilder;
 import org.cru.godtools.domain.authentication.AuthorizationService;
@@ -110,7 +110,7 @@ public class PackageResourceTest extends AbstractFullPackageServiceTest
 
 		Assert.assertEquals(response.getStatus(), 200);
 
-		validateContentsXml((Content)response.getEntity());
+		validateContentsXml((ContentsFile)response.getEntity());
 	}
 
 	/**
@@ -135,7 +135,7 @@ public class PackageResourceTest extends AbstractFullPackageServiceTest
 
 		Assert.assertEquals(response.getStatus(), 200);
 
-		validateContentsXml((Content)response.getEntity());
+		validateContentsXml((ContentsFile)response.getEntity());
 	}
 
 	/**
@@ -186,11 +186,11 @@ public class PackageResourceTest extends AbstractFullPackageServiceTest
 		zipInputStream.forceClose();
 	}
 
-	private void validateContentsXml(Content xmlContentsFile)
+	private void validateContentsXml(ContentsFile xmlContentsFile)
 	{
 		Assert.assertEquals(xmlContentsFile.getResourceSet().size(), 1);
 
-		Resource firstResource = xmlContentsFile.getResourceSet().iterator().next();
+		ResourceElement firstResource = xmlContentsFile.getResourceSet().iterator().next();
 
 		Assert.assertEquals(firstResource.getLanguage(), "en");
 		Assert.assertEquals(firstResource.getPackageCode(), "kgp");

--- a/src/test/java/org/cru/godtools/api/translations/DraftResourceTest.java
+++ b/src/test/java/org/cru/godtools/api/translations/DraftResourceTest.java
@@ -1,8 +1,8 @@
 package org.cru.godtools.api.translations;
 
 import org.cru.godtools.api.packages.utils.FileZipper;
-import org.cru.godtools.api.translations.model.Content;
-import org.cru.godtools.api.translations.model.Resource;
+import org.cru.godtools.api.translations.model.ContentsFile;
+import org.cru.godtools.api.translations.model.ResourceElement;
 import org.cru.godtools.domain.TestSqlConnectionProducer;
 import org.cru.godtools.domain.UnittestDatabaseBuilder;
 import org.cru.godtools.domain.authentication.AuthorizationService;
@@ -84,7 +84,7 @@ public class DraftResourceTest extends AbstractFullPackageServiceTest
 		// auth token does not have access to drafts
 		Response response = draftResource.getTranslation("en", "kgp", 1, null, "false", new BigDecimal("1.1"), "draft-access", null);
 
-		validateContentsXml((Content)response.getEntity());
+		validateContentsXml((ContentsFile)response.getEntity());
 	}
 
 	@Test
@@ -93,7 +93,7 @@ public class DraftResourceTest extends AbstractFullPackageServiceTest
 		// auth token does not have access to drafts
 		Response response = draftResource.getTranslations("en", 1, null, "false", "draft-access", null);
 
-		validateContentsXml((Content)response.getEntity());
+		validateContentsXml((ContentsFile)response.getEntity());
 	}
 
 	@Test(expectedExceptions = UnauthorizedException.class)
@@ -103,11 +103,11 @@ public class DraftResourceTest extends AbstractFullPackageServiceTest
 		draftResource.getTranslation("en", "kgp", 1, null, "false", new BigDecimal("1.1"), "a", null);
 	}
 
-	private void validateContentsXml(Content xmlContentsFile)
+	private void validateContentsXml(ContentsFile xmlContentsFile)
 	{
 		Assert.assertEquals(xmlContentsFile.getResourceSet().size(), 1);
 
-		Resource firstResource = xmlContentsFile.getResourceSet().iterator().next();
+		ResourceElement firstResource = xmlContentsFile.getResourceSet().iterator().next();
 
 		Assert.assertEquals(firstResource.getLanguage(), "en");
 		Assert.assertEquals(firstResource.getPackageCode(), "kgp");

--- a/src/test/java/org/cru/godtools/api/translations/TranslationResourceTest.java
+++ b/src/test/java/org/cru/godtools/api/translations/TranslationResourceTest.java
@@ -2,8 +2,8 @@ package org.cru.godtools.api.translations;
 
 import org.ccci.util.xml.XmlDocumentSearchUtilities;
 import org.cru.godtools.api.packages.utils.FileZipper;
-import org.cru.godtools.api.translations.model.Content;
-import org.cru.godtools.api.translations.model.Resource;
+import org.cru.godtools.api.translations.model.ContentsFile;
+import org.cru.godtools.api.translations.model.ResourceElement;
 import org.cru.godtools.domain.TestSqlConnectionProducer;
 import org.cru.godtools.domain.UnittestDatabaseBuilder;
 import org.cru.godtools.domain.authentication.AuthorizationService;
@@ -111,7 +111,7 @@ public class TranslationResourceTest extends AbstractFullPackageServiceTest
 
 		Assert.assertEquals(response.getStatus(), 200);
 
-		validateContentsXml((Content)response.getEntity());
+		validateContentsXml((ContentsFile)response.getEntity());
 	}
 
 	/**
@@ -134,7 +134,7 @@ public class TranslationResourceTest extends AbstractFullPackageServiceTest
 
 		Assert.assertEquals(response.getStatus(), 200);
 
-		validateContentsXml((Content)response.getEntity());
+		validateContentsXml((ContentsFile)response.getEntity());
 	}
 
 	/**
@@ -201,7 +201,7 @@ public class TranslationResourceTest extends AbstractFullPackageServiceTest
 		Assert.assertEquals(getDraftResponse.getStatus(), 200);
 
 
-		validateDraftXml((Content)getDraftResponse.getEntity(), "fr");
+		validateDraftXml((ContentsFile)getDraftResponse.getEntity(), "fr");
 	}
 
 	@Test
@@ -227,7 +227,7 @@ public class TranslationResourceTest extends AbstractFullPackageServiceTest
 
 		Assert.assertEquals(getDraftResponse.getStatus(), 200);
 
-		validateDraftXml((Content)getDraftResponse.getEntity(), "en");
+		validateDraftXml((ContentsFile)getDraftResponse.getEntity(), "en");
 	}
 
 	@Test(expectedExceptions = UnauthorizedException.class)
@@ -265,15 +265,15 @@ public class TranslationResourceTest extends AbstractFullPackageServiceTest
 
 		Assert.assertEquals(publishedTranslationResponse.getStatus(), 200);
 
-		validateContentsXml((Content)publishedTranslationResponse.getEntity());
+		validateContentsXml((ContentsFile)publishedTranslationResponse.getEntity());
 	}
 
 
-	private void validateDraftXml(Content xmlContentsFile, String languageCode)
+	private void validateDraftXml(ContentsFile xmlContentsFile, String languageCode)
 	{
 		Assert.assertEquals(xmlContentsFile.getResourceSet().size(), 1);
 
-		Resource firstResource = xmlContentsFile.getResourceSet().iterator().next();
+		ResourceElement firstResource = xmlContentsFile.getResourceSet().iterator().next();
 
 		Assert.assertEquals(firstResource.getLanguage(), languageCode);
 		Assert.assertEquals(firstResource.getPackageCode(), "kgp");
@@ -293,11 +293,11 @@ public class TranslationResourceTest extends AbstractFullPackageServiceTest
 		}
 	}
 
-	private void validateContentsXml(Content xmlContentsFile)
+	private void validateContentsXml(ContentsFile xmlContentsFile)
 	{
 		Assert.assertEquals(xmlContentsFile.getResourceSet().size(), 1);
 		
-		Resource firstResource = xmlContentsFile.getResourceSet().iterator().next();
+		ResourceElement firstResource = xmlContentsFile.getResourceSet().iterator().next();
 		
 		Assert.assertEquals(firstResource.getLanguage(), "en");
 		Assert.assertEquals(firstResource.getPackageCode(), "kgp");


### PR DESCRIPTION
Adds endpoints that are required by a God Tools webapp that is to be developed.
New endpoints include:
 - GET: translations/{langaugeCode}/{packageCode}/config
   - returns in JSON an array of pages that compose a God Tools package in a specific language
   - filenames of the requested pages are included
 - GET: translations/{langaugeCode}/{packageCode}/pages/{pageId}
   - returns in JSON format an map (key/value pairs) of translated strings for a specific page, translated to a specific language
   - this assumes that the webapp will know where the text should go based on its ID.  those who are developing the webapp know this.