### PR TITLE
Bug squash

### DIFF
--- a/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
+++ b/src/main/java/org/cru/godtools/api/translations/TranslationResource.java
@@ -92,9 +92,8 @@ public class TranslationResource
 
 		AuthorizationRecord.checkAccessToDrafts(authService.getAuthorizationRecord(authTokenParam, authTokenHeader), clock.currentDateTime());
 
-		draftTranslation.create(languageCode,packageCode);
+		draftTranslation.create(new LanguageCode(languageCode),packageCode);
 
-		// FIXME: this isn't quite right yet... major version number should not be hard coded, but for now the API doesn't support updating it
 		return Response
 				.status(Response.Status.CREATED)
 				.build();

--- a/src/main/java/org/cru/godtools/api/v2/LanguageResource.java
+++ b/src/main/java/org/cru/godtools/api/v2/LanguageResource.java
@@ -6,6 +6,7 @@ import org.cru.godtools.api.v2.functions.DraftTranslation;
 import org.cru.godtools.domain.authentication.AuthorizationRecord;
 import org.cru.godtools.domain.authentication.AuthorizationService;
 import org.cru.godtools.domain.languages.Language;
+import org.cru.godtools.domain.languages.LanguageCode;
 import org.cru.godtools.domain.languages.LanguageService;
 import org.cru.godtools.domain.packages.Package;
 import org.cru.godtools.domain.packages.PackageService;
@@ -65,7 +66,7 @@ public class LanguageResource
 
 		for(Package gtPackage : packageService.selectAllPackages())
 		{
-			draftTranslation.create(language.getCode(), gtPackage.getCode());
+			draftTranslation.create(LanguageCode.fromLanguage(language), gtPackage.getCode());
 		}
 
 		authorizationService.updateAdminRecordExpiration(authorizationRecord.get(), 4);

--- a/src/main/java/org/cru/godtools/api/v2/LanguageResource.java
+++ b/src/main/java/org/cru/godtools/api/v2/LanguageResource.java
@@ -40,6 +40,14 @@ public class LanguageResource
 	@Consumes(MediaType.APPLICATION_JSON)
 	public Response addLanguage(Language language, @HeaderParam("Authorization") String authorization)
 	{
+		if(language == null)
+		{
+			return Response
+					.status(Response.Status.BAD_REQUEST)
+					.entity("Language was missing")
+					.build();
+		}
+
 		Optional<AuthorizationRecord> authorizationRecord = authorizationService.getAuthorizationRecord(authorization, null);
 
 		AuthorizationRecord.checkAdminAccess(authorizationRecord, clock.currentDateTime());

--- a/src/main/java/org/cru/godtools/api/v2/TranslationResource.java
+++ b/src/main/java/org/cru/godtools/api/v2/TranslationResource.java
@@ -5,6 +5,7 @@ import org.cru.godtools.api.v2.functions.DraftTranslation;
 import org.cru.godtools.api.v2.functions.PublishedTranslation;
 import org.cru.godtools.domain.authentication.AuthorizationRecord;
 import org.cru.godtools.domain.authentication.AuthorizationService;
+import org.cru.godtools.domain.languages.LanguageCode;
 import org.cru.godtools.s3.AmazonS3GodToolsConfig;
 import org.cru.godtools.s3.GodToolsS3Client;
 import org.jboss.logging.Logger;
@@ -77,7 +78,7 @@ public class TranslationResource
 
 		AuthorizationRecord.checkAccessToDrafts(authService.getAuthorizationRecord(authTokenParam, authTokenHeader), clock.currentDateTime());
 
-		draftTranslation.create(languageCode, packageCode);
+		draftTranslation.create(new LanguageCode(languageCode), packageCode);
 
 		return Response
 				.created(new URI("/drafts" + languageCode + "/" + packageCode))

--- a/src/main/java/org/cru/godtools/api/v2/functions/DraftTranslation.java
+++ b/src/main/java/org/cru/godtools/api/v2/functions/DraftTranslation.java
@@ -8,6 +8,7 @@ import org.cru.godtools.domain.packages.PageStructure;
 import org.cru.godtools.domain.packages.TranslationElement;
 import org.cru.godtools.domain.translations.Translation;
 import org.cru.godtools.translate.client.TranslationUpload;
+import org.jboss.logging.Logger;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -15,11 +16,14 @@ import java.util.UUID;
 
 public class DraftTranslation extends AbstractTranslation
 {
+	Logger logger = Logger.getLogger(getClass());
+
 	@Inject
 	TranslationUpload translationUpload;
 
 	public void create(LanguageCode languageCode, String packageCode)
 	{
+		logger.info(String.format("Creating draft with languageCode %s and packageCode %s", languageCode.toString(), packageCode));
 		Package gtPackage = packageService.selectByCode(packageCode);
 		Language language = languageService.selectByLanguageCode(languageCode);
 		Translation baseTranslation = null;
@@ -29,20 +33,30 @@ public class DraftTranslation extends AbstractTranslation
 				gtPackage.getId(),
 				GodToolsVersion.LATEST_VERSION);
 
+		logger.info(String.format("Found translation? %s", currentTranslation != null));
+
 		// only allow one draft per translation
 		if(currentTranslation != null && currentTranslation.isDraft()) return;
 
+		logger.info("Continuing to create draft");
+
 		Translation newTranslation = saveNewTranslation(gtPackage, language, currentTranslation);
+
+		logger.info("Created new translation");
 
 		if(currentTranslation == null)
 		{
+			logger.info("Setting base translation");
 			baseTranslation = loadBaseTranslation(gtPackage.getId());
+
 		}
 
+		logger.info("Copying page translation data");
 		copyPageAndTranslationData(currentTranslation == null ? baseTranslation : currentTranslation,
 				newTranslation,
 				false);
 
+		logger.info("Copying package translation data");
 		copyPackageTranslationData(currentTranslation == null ? baseTranslation : currentTranslation,
 				newTranslation);
 

--- a/src/main/java/org/cru/godtools/api/v2/functions/DraftTranslation.java
+++ b/src/main/java/org/cru/godtools/api/v2/functions/DraftTranslation.java
@@ -66,7 +66,7 @@ public class DraftTranslation extends AbstractTranslation
 	public void publish(String languageCode, String packageCode)
 	{
 		Package gtPackage = packageService.selectByCode(packageCode);
-		Language language = languageService.getOrCreateLanguage(new LanguageCode(languageCode));
+		Language language = languageService.selectByLanguageCode(new LanguageCode(languageCode));
 
 		// try to load out the latest version of translation for this package/language combo
 		Translation currentTranslation = translationService.selectByLanguageIdPackageIdVersionNumber(language.getId(),

--- a/src/main/java/org/cru/godtools/api/v2/functions/DraftTranslation.java
+++ b/src/main/java/org/cru/godtools/api/v2/functions/DraftTranslation.java
@@ -18,10 +18,10 @@ public class DraftTranslation extends AbstractTranslation
 	@Inject
 	TranslationUpload translationUpload;
 
-	public void create(String languageCode, String packageCode)
+	public void create(LanguageCode languageCode, String packageCode)
 	{
 		Package gtPackage = packageService.selectByCode(packageCode);
-		Language language = languageService.getOrCreateLanguage(new LanguageCode(languageCode));
+		Language language = languageService.selectByLanguageCode(languageCode);
 		Translation baseTranslation = null;
 
 		// try to load out the latest version of translation for this package/language combo

--- a/src/main/java/org/cru/godtools/domain/languages/LanguageCode.java
+++ b/src/main/java/org/cru/godtools/domain/languages/LanguageCode.java
@@ -68,15 +68,10 @@ public class LanguageCode
         String[] languageCodeParts = providedLanguageCode.split("-");
 
         //if the languageCode isn't split, then there was no underscore. there is no locale (e.g. en.xml)
-        if(languageCodeParts.length == 1) return null;
+        if(languageCodeParts.length <= 1) return null;
 
         //if the length is greater than two, the locale is always the 2nd item, so return it.
-        if(languageCodeParts.length > 2) return languageCodeParts[1];
-
-        //we haven't returned yet, so there are two elements.  if the 2nd element is 2 or less characters it's a locale, if not, return null.. it's a subculture
-        if(languageCodeParts[1].length() <= 2) return languageCodeParts[1];
-
-        return null;
+        return languageCodeParts[1];
     }
 
     public String getSubculture()
@@ -84,14 +79,8 @@ public class LanguageCode
         String[] languageCodeParts = providedLanguageCode.split("-");
 
         //if the languageCode isn't split, then there was no underscore. there is no locale (e.g. en.xml)
-        if(languageCodeParts.length == 1) return null;
+        if(languageCodeParts.length <= 2) return null;
 
-        //if the length is greater than two, the locale is always the 3rd item, so return it.
-        if(languageCodeParts.length > 2) return languageCodeParts[2];
-
-        //we haven't returned yet, so there are two elements.  if the 2nd element is more than 2 characters it's a locale, if not, return null.. it's a subculture
-        if(languageCodeParts[1].length() > 2) return languageCodeParts[1];
-
-        return null;
+        return languageCodeParts[2];
     }
 }

--- a/src/main/java/org/cru/godtools/domain/languages/LanguageService.java
+++ b/src/main/java/org/cru/godtools/domain/languages/LanguageService.java
@@ -54,16 +54,16 @@ public class LanguageService
 				.executeAndFetchFirst(Language.class);
 	}
 
-	public Language selectByLanguageCode(LanguageCode languangeCode)
+	public Language selectByLanguageCode(LanguageCode languageCode)
 	{
-		List<Language> possibleMatches = selectLanguageByStringCode(languangeCode.getLanguageCode());
+		List<Language> possibleMatches = selectLanguageByStringCode(languageCode.getLanguageCode());
 
 		for(Language possibleMatch : possibleMatches)
 		{
-			boolean matched = true;
+			String passedLocaleCode = languageCode.getLocaleCode();
+			String retrievedLocalCode = possibleMatch.getLocale();
 
-			if(!Strings.nullToEmpty(languangeCode.getLocaleCode()).equalsIgnoreCase(Strings.nullToEmpty(possibleMatch.getLocale()))) matched = false;
-			if(!Strings.nullToEmpty(languangeCode.getSubculture()).equalsIgnoreCase(Strings.nullToEmpty(possibleMatch.getSubculture()))) matched = false;
+			boolean matched = Strings.nullToEmpty(passedLocaleCode).equalsIgnoreCase(Strings.nullToEmpty(retrievedLocalCode));
 
 			if(matched) return possibleMatch;
 		}


### PR DESCRIPTION
- reduce usage of deprecated `languageService.getOrCreateLanguage() method
  - this caused issues where a language would be added twice in some cases
- have `DraftTranslation.create()` take a `LanguageCode` instance instead of a `String languageCode`
  - this caused issues b/c the locale was ignored when adding a language that included a locale code.
- added some logging to help diagnose issues
- always treat language codes as language-locale-subculture
  - there was previously logic treated something like 'en-military' as language-subculture b/c the second part of the code was > 2 characters.  this was confusing, and totally unused.
- return a bad request if a language entity is missing on create language endpoint