### PR TITLE
Fix missing names

### DIFF
--- a/src/main/java/org/cru/godtools/api/translations/GodToolsTranslation.java
+++ b/src/main/java/org/cru/godtools/api/translations/GodToolsTranslation.java
@@ -76,37 +76,6 @@ public class GodToolsTranslation implements Serializable
 	}
 
 	/**
-	 * Returns a list of file names.  These file names correspond to files of translated text in the translation tool.
-	 *
-	 * This set includes the list of each individual page within the package, as well as the name of the file which has
-	 * the packages 'meta' data (package name, page names).
-	 */
-	public Set<String> getFilenameSet()
-	{
-		Set<String> filenameSet = Sets.newHashSet();
-
-		for(PageStructure pageStructure : pageStructureList)
-		{
-			filenameSet.add(pageStructure.getFilename());
-		}
-
-		filenameSet.add(packageStructure.getFilename());
-
-		return filenameSet;
-	}
-
-	public void replacePageXml(PageStructure updatedPageStructure)
-	{
-		for(PageStructure pageStructure : pageStructureList)
-		{
-			if(pageStructure.getId().equals(updatedPageStructure.getId()))
-			{
-				pageStructure.setXmlContent(updatedPageStructure.getXmlContent());
-			}
-		}
-	}
-
-	/**
 	 * You can't have one without the other
 	 * @return
 	 */

--- a/src/main/java/org/cru/godtools/api/v2/functions/AbstractTranslation.java
+++ b/src/main/java/org/cru/godtools/api/v2/functions/AbstractTranslation.java
@@ -120,7 +120,7 @@ public abstract class AbstractTranslation
 	{
 		for(PageStructure pageStructure : pageStructureService.selectByTranslationId(currentTranslation.getId()))
 		{
-			logger.info(String.format("Downloading page with ID %s from OneSky for %s in language %s", pageStructure.getId(), gtPackage.getCode(), language.getName()));
+			logger.info(String.format("Downloading page with ID %s from OneSky for %s in %s", pageStructure.getId(), gtPackage.getCode(), language.getName()));
 
 			TranslationResults downloadedTranslations = translationDownload.doDownload(gtPackage.getTranslationProjectId(),
 					language.getPath(),
@@ -132,6 +132,23 @@ public abstract class AbstractTranslation
 						currentTranslation.getId(),
 						downloadedTranslations.get(translatedElementId));
 			}
+		}
+
+		logger.info(String.format("Downloading \"package page\" with filename %s%s from Onesky for %s in %s",
+				gtPackage.getCode(),
+				".xml",
+				gtPackage.getName(),
+				language.getName()));
+
+		TranslationResults downloadedTranslations = translationDownload.doDownload(gtPackage.getTranslationProjectId(),
+				language.getPath(),
+				gtPackage.getCode().concat(".xml"));
+
+		for(UUID translatedElementId : downloadedTranslations.keySet())
+		{
+			translationElementService.update(translatedElementId,
+					currentTranslation.getId(),
+					downloadedTranslations.get(translatedElementId));
 		}
 	}
 

--- a/src/main/java/org/cru/godtools/translate/client/onesky/OneSkyTranslationDownload.java
+++ b/src/main/java/org/cru/godtools/translate/client/onesky/OneSkyTranslationDownload.java
@@ -23,7 +23,7 @@ public class OneSkyTranslationDownload implements TranslationDownload
 		this.properties = properties;
 	}
 
-	private Logger log = Logger.getLogger(OneSkyTranslationUpload.class);
+	private Logger log = Logger.getLogger(getClass());
 
 	@Override
 	public TranslationResults doDownload(Integer oneSkyProjectId, String locale, String pageName)


### PR DESCRIPTION
This PR downloads the files in from OneSky that contain the values to show translated package/booklet names and translated page names.  The code to assemble the return value will know what to do with them once they are downloaded.