### PR TITLE
Look in the proper element for about filename

### DIFF
--- a/src/main/java/org/cru/godtools/api/translations/model/ConfigFile.java
+++ b/src/main/java/org/cru/godtools/api/translations/model/ConfigFile.java
@@ -66,7 +66,7 @@ public class ConfigFile
 		}
 		for(Element element : XmlDocumentSearchUtilities.findElements(xmlPackageStructure, "about"))
 		{
-			configFile.about.setFilename(element.getAttribute("about"));
+			configFile.about.setFilename(element.getAttribute("filename").replace(".xml",""));
 			configFile.about.setTitle(element.getTextContent());
 		}
 


### PR DESCRIPTION
Follows the pattern for other pages where the XML is removed. I think this is because the filename has already been mapped to a UUID and for the clients' sake the '.xml' is removed.  I've not confirmed this however